### PR TITLE
Support Yarn v2

### DIFF
--- a/bin/install-from-cache.js
+++ b/bin/install-from-cache.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const {promises: fsp} = require('fs');
+const {promises: fsp, existsSync} = require('fs');
 const path = require('path');
 const zlib = require('zlib');
 const {promisify} = require('util');
@@ -138,6 +138,13 @@ const write = async (name, data) => {
 
 const main = async () => {
   checks: {
+    if (!process.env.npm_package_json && process.env.PWD) {
+      const package_json_path = path.join(process.env.PWD, 'package.json')
+      if (existsSync(package_json_path)) {
+        process.env.npm_package_json = package_json_path
+      }
+    }
+
     if (process.env.npm_package_json && /\bpackage\.json$/i.test(process.env.npm_package_json)) {
       // for NPM >= 7
       try {


### PR DESCRIPTION
I'm using Yarn and I found that Yarn has to rebuild `node-re2` every time in the CI pipeline. The reason is that Yarn doesn't provide the environment variable `npm_package_json`. In this PR, I use the environment variable `PWD` to support Yarn (and also other package managers). 