### PR TITLE
Ability to specify platform

### DIFF
--- a/bin/install-from-cache.js
+++ b/bin/install-from-cache.js
@@ -11,8 +11,8 @@ const {exec, spawnSync} = require('child_process');
 
 const spawnOptions = {encoding: 'utf8', env: process.env};
 const getPlatform = () => {
-  const platform = process.platform;
-  if (platform !== 'linux') return platform;
+  const platform = process.env.npm_config_platform || process.platform;
+  if (platform !== 'linux' || process.env.npm_config_platform) return platform;
   // detecting musl using algorithm from https://github.com/lovell/detect-libc under Apache License 2.0
   let result = spawnSync('getconf', ['GNU_LIBC_VERSION'], spawnOptions);
   if (!result.status && !result.signal) return platform;
@@ -90,6 +90,8 @@ const run = async (cmd, suppressOutput) =>
   });
 
 const isVerified = async () => {
+  if (process.env.npm_config_platform) return true
+
   try {
     if (process.env.npm_package_scripts_verify_build) {
       await run('npm run verify-build', true);


### PR DESCRIPTION
With this change it's possible to install re2 package for specific platform (e.g. `npm install re2 --platform=linux`). I had a problem with deployment to AWS Lambda as it uses `linux` platform while macOS is `darwin`. [Sharp](https://github.com/lovell/sharp) has this configuration too.