### PR TITLE
Fix connection keep-alive

### DIFF
--- a/bin/install-from-cache.js
+++ b/bin/install-from-cache.js
@@ -140,7 +140,7 @@ const get = async url =>
     }
     let buffer = null;
     httpLib
-      .get(url, res => {
+      .get(url, { agent: false }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers && res.headers.location) {
           get(res.headers.location).then(resolve, reject);
           return;


### PR DESCRIPTION
This patch fixes the node process waiting for the connection to close for ~2 minutes after the process is complete

Installing re2 without this patch takes 2 minutes, with this patch 6 seconds